### PR TITLE
Support multi-coord move and line command

### DIFF
--- a/src/typography/font.nim
+++ b/src/typography/font.nim
@@ -186,6 +186,9 @@ proc glyphPathToCommands*(glyph: var Glyph) =
       of ' ', ',':
         finishDigit()
       else:
+        if command == Move and numbers.len == 2:
+          finishCommand()
+          command = Line
         number &= c
 
   finishCommand()

--- a/src/typography/font.nim
+++ b/src/typography/font.nim
@@ -189,6 +189,9 @@ proc glyphPathToCommands*(glyph: var Glyph) =
         if command == Move and numbers.len == 2:
           finishCommand()
           command = Line
+        elif command == Line and numbers.len == 2:
+          finishCommand()
+          command = Line
         number &= c
 
   finishCommand()
@@ -292,6 +295,17 @@ proc commandsToShapes*(glyph: var Glyph) =
         to.y = command.numbers[1]
         ctr = at - (ctr - at)
         drawQuad(at, ctr, to)
+        at = to
+
+      of Cubic:
+        assert command.numbers.len == 6
+        ctr.x = command.numbers[0]
+        ctr.y = command.numbers[1]
+        ctr2.x = command.numbers[2]
+        ctr2.y = command.numbers[3]
+        to.x = command.numbers[4]
+        to.y = command.numbers[5]
+        drawCurve(@[at, ctr, ctr2, to])
         at = to
 
       of End:


### PR DESCRIPTION
From the [MDN SVG path spec](https://developer.mozilla.org/en-US/docs/Web/SVG/Attribute/d):

M | (x, y)+ | Move the current point to the coordinate x,y. Any subsequent coordinate pair(s) are interpreted as parameter(s) for implicit absolute LineTo (L) command(s) (see below). Formula: Pn = {x, y}
-- | -- | --

Many of the other SVG path commands also have optional repetitions of their coordinates, but fixing Move and Line was sufficient to let me load [the font](http://www.cnap.graphismeenfrance.fr/faune/en.html) I was trying to load. You may want to change the way this part of the code works to accommodate more repeated commands. (Or maybe my edit here will scale just fine to other commands, I'm not sure.)

Also implemented the absolute-coordinate Cubic command since that was missing!